### PR TITLE
Remove useless :prefix property.

### DIFF
--- a/flycheck-moonscript.el
+++ b/flycheck-moonscript.el
@@ -54,8 +54,7 @@
   :command ("moonc" "-l" source)
   :error-patterns ((warning line-start "line " line ": " (message))
                    (error line-start (message) ":\n [" line "]"))
-  :modes moonscript-mode
-  :prefix flycheck-buffer-saved-p)
+  :modes moonscript-mode)
 
 (add-to-list 'flycheck-checkers 'moonscript-moonc)
 (add-to-list 'flycheck-checkers 'moonscript-moonpick)


### PR DESCRIPTION
The :prefix flag to flycheck-define-checker gets removed during
macro expansion and is therefore useless.